### PR TITLE
Artifact Endpoint

### DIFF
--- a/gocd/api/__init__.py
+++ b/gocd/api/__init__.py
@@ -1,4 +1,5 @@
-__all__ = ['Pipeline', 'PipelineGroups']
+__all__ = ['Pipeline', 'PipelineGroups', 'Artifact']
 
 from .pipeline import Pipeline
 from .pipeline_groups import PipelineGroups
+from .artifact import Artifact

--- a/gocd/api/artifact.py
+++ b/gocd/api/artifact.py
@@ -1,0 +1,88 @@
+from gocd.api.endpoint import Endpoint
+
+
+class Artifact(Endpoint):
+    base_path = 'go/files/{pipeline}/{counter}/{stage}/{stage_counter}/{job}'
+
+    def __init__(self, server, pipeline, counter, stage, job, stage_counter=1):
+        """A wrapper for the `Go artifact API`__
+
+        .. __: http://api.go.cd/current/#artifacts
+
+        Args:
+          server (Server): A configured instance of
+            :class:gocd.server.Server
+          pipeline (str): The name of the pipeline to work with
+          counter (int): The counter of the pipeline to work with
+          stage (str): The name of the stage to work with
+          job (str): The name of the job to work with
+          stage_counter (int): The counter of the stage to work with, defaults to 1
+        """
+        self.server = server
+        self.pipeline = pipeline
+        self.counter = counter
+        self.stage = stage
+        self.job = job
+        self.stage_counter = stage_counter
+
+        self._base_path = self.base_path.format(
+            pipeline=self.pipeline,
+            counter=self.counter,
+            stage=self.stage,
+            stage_counter=self.stage_counter,
+            job=self.job
+        )
+
+    def list(self):
+        """Lists all available artifacts in this job.
+
+        See the `Go artifact list documentation`__ for example responses.
+
+        .. __: http://api.go.cd/current/#get-all-artifacts
+
+        Returns:
+          Response: :class:`gocd.api.response.Response` object
+        """
+        return self._get('.json')
+
+    def get(self, path_to_file):
+        """Gets an artifact directory by its path.
+
+        See the `Go artifact file documentation`__ for example responses.
+
+        .. __: http://api.go.cd/current/#get-artifact-file
+
+        Args:
+          path_to_file (str): The path to file to get. It can be nested eg
+            ```dist/foobar-widgets-1.2.0.jar```
+
+        Returns:
+          file like object: The response from a
+            :func:`urllib2.urlopen` call
+        """
+        return self.server.request(
+            self._join_path(path_to_file),
+            data=None,
+            headers=None
+        )
+
+    def get_directory(self, path_to_directory):
+        """Gets an artifact directory by its path.
+
+        See the `Go artifact directory documentation`__ for example responses.
+
+        .. __: http://api.go.cd/current/#get-artifact-directory
+
+        Args:
+          path_to_directory (str): The path to the directory to get.
+            It can be nested eg ```target/dist.zip```
+
+        Returns:
+          file like object: The response from a
+            :func:`urllib2.urlopen` call
+        """
+        return self.server.request(
+            self._join_path(path_to_directory + ".zip"),
+            data=None,
+            headers=None
+        )

--- a/tests/api/test_artifact.py
+++ b/tests/api/test_artifact.py
@@ -1,0 +1,56 @@
+import pytest
+import vcr
+import zipfile
+import io
+import time
+
+import gocd
+
+
+@pytest.fixture
+def server():
+    return gocd.Server('http://192.168.24.67:32769')
+
+
+@pytest.fixture
+def artifact(server):
+    return gocd.api.Artifact(server, "Art", 2, "defaultStage", "defaultJob", 3)
+
+
+@vcr.use_cassette('tests/fixtures/cassettes/api/artifact/list.yml')
+def test_release(artifact):
+    response = artifact.list()
+
+    assert response.is_ok
+    assert response.content_type == 'application/json'
+    assert len(response.payload) == 3
+    assert set(x["name"] for x in response) == set(["cruise-output", "foo", "output.txt"])
+    foo = next(x for x in response if x["name"] == "foo")
+    assert len(foo["files"]) == 2
+
+
+@pytest.mark.parametrize('cassette_name,path_to_file, expected_content', [
+    ('tests/fixtures/cassettes/api/artifact/get-output.yml', "output.txt", "3239273"),
+    ('tests/fixtures/cassettes/api/artifact/get-foo-a.yml', "foo/a.txt", "5933126")
+])
+def test_get(artifact, cassette_name, path_to_file, expected_content):
+    with vcr.use_cassette(cassette_name):
+        response = artifact.get(path_to_file)
+
+    assert response.code == 200
+    assert response.read() == expected_content
+
+
+@vcr.use_cassette('tests/fixtures/cassettes/api/artifact/get_directory.yml')
+def test_get_directory(artifact):
+    for i in xrange(10):
+        response = artifact.get_directory("foo")
+        if response.code != 202:
+            break
+        time.sleep(0.1)
+
+    assert response.code == 200
+
+    file_like_object = io.BytesIO(response.read())
+    zip_file = zipfile.ZipFile(file_like_object)
+    assert set(['foo/', 'foo/a.txt', 'foo/b.txt']) == set(zip_file.namelist())

--- a/tests/fixtures/cassettes/api/artifact/get-foo-a.yml
+++ b/tests/fixtures/cassettes/api/artifact/get-foo-a.yml
@@ -1,0 +1,23 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: ['192.168.24.67:32769']
+      User-Agent: [py-gocd]
+    method: GET
+    uri: http://192.168.24.67:32769/go/files/Art/2/defaultStage/3/defaultJob/foo/a.txt
+  response:
+    body: {string: !!python/unicode '5933126'}
+    headers:
+      connection: [close]
+      content-language: [en-US]
+      content-length: ['7']
+      content-type: [text/plain]
+      date: ['Wed, 16 Sep 2015 12:58:13 GMT']
+      expires: ['Thu, 01 Jan 1970 00:00:00 GMT']
+      server: [Jetty(9.2.z-SNAPSHOT)]
+      set-cookie: ['JSESSIONID=16nzbhc03z0yn1geuinokmzyx5;Path=/go;Expires=Wed, 30-Sep-2015
+          12:58:13 GMT']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/api/artifact/get-output.yml
+++ b/tests/fixtures/cassettes/api/artifact/get-output.yml
@@ -1,0 +1,23 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: ['192.168.24.67:32769']
+      User-Agent: [py-gocd]
+    method: GET
+    uri: http://192.168.24.67:32769/go/files/Art/2/defaultStage/3/defaultJob/output.txt
+  response:
+    body: {string: !!python/unicode '3239273'}
+    headers:
+      connection: [close]
+      content-language: [en-US]
+      content-length: ['7']
+      content-type: [text/plain]
+      date: ['Wed, 16 Sep 2015 12:58:13 GMT']
+      expires: ['Thu, 01 Jan 1970 00:00:00 GMT']
+      server: [Jetty(9.2.z-SNAPSHOT)]
+      set-cookie: ['JSESSIONID=1srne8apekdql1dch0gvmwo7mu;Path=/go;Expires=Wed, 30-Sep-2015
+          12:58:13 GMT']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/api/artifact/get_directory.yml
+++ b/tests/fixtures/cassettes/api/artifact/get_directory.yml
@@ -1,0 +1,47 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: ['192.168.24.67:32769']
+      User-Agent: [py-gocd]
+    method: GET
+    uri: http://192.168.24.67:32769/go/files/Art/2/defaultStage/3/defaultJob/foo.zip
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      connection: [close]
+      content-language: [en-US]
+      date: ['Wed, 16 Sep 2015 12:58:13 GMT']
+      expires: ['Thu, 01 Jan 1970 00:00:00 GMT']
+      server: [Jetty(9.2.z-SNAPSHOT)]
+      set-cookie: ['JSESSIONID=1k2y18mi4d3oarkeqbapk5uc2;Path=/go;Expires=Wed, 30-Sep-2015
+          12:58:13 GMT']
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Cookie: [JSESSIONID=1k2y18mi4d3oarkeqbapk5uc2]
+      Host: ['192.168.24.67:32769']
+      User-Agent: [py-gocd]
+    method: GET
+    uri: http://192.168.24.67:32769/go/files/Art/2/defaultStage/3/defaultJob/foo.zip
+  response:
+    body:
+      string: !!binary |
+        UEsDBBQACAgIAEZnMEcAAAAAAAAAAAAAAAAEAAAAZm9vLwMAUEsHCAAAAAACAAAAAAAAAFBLAwQU
+        AAgICABAZzBHAAAAAAAAAAAAAAAACQAAAGZvby9hLnR4dDO1NDY2NDIDAFBLBwi42D5HCQAAAAcA
+        AABQSwMEFAAICAgAQGcwRwAAAAAAAAAAAAAAAAkAAABmb28vYi50eHQztTQ2NjQyAwBQSwcIuNg+
+        RwkAAAAHAAAAUEsBAhQAFAAICAgARmcwRwAAAAACAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAGZv
+        by9QSwECFAAUAAgICABAZzBHuNg+RwkAAAAHAAAACQAAAAAAAAAAAAAAAAA0AAAAZm9vL2EudHh0
+        UEsBAhQAFAAICAgAQGcwR7jYPkcJAAAABwAAAAkAAAAAAAAAAAAAAAAAdAAAAGZvby9iLnR4dFBL
+        BQYAAAAAAwADAKAAAAC0AAAAAAA=
+    headers:
+      connection: [close]
+      content-language: [en-US]
+      content-type: [application/zip]
+      date: ['Wed, 16 Sep 2015 12:58:13 GMT']
+      server: [Jetty(9.2.z-SNAPSHOT)]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/api/artifact/list.yml
+++ b/tests/fixtures/cassettes/api/artifact/list.yml
@@ -1,0 +1,32 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: ['192.168.24.67:32769']
+      User-Agent: [py-gocd]
+    method: GET
+    uri: http://192.168.24.67:32769/go/files/Art/2/defaultStage/3/defaultJob/.json
+  response:
+    body: {string: !!python/unicode '[ { "name": "cruise-output","url": "http://192.168.24.67:32769/go/files/Art/2/defaultStage/3/defaultJob/cruise-output","type":
+        "folder","files": [ { "name": "console.log","url": "http://192.168.24.67:32769/go/files/Art/2/defaultStage/3/defaultJob/cruise-output/console.log","type":
+        "file" },{ "name": "md5.checksum","url": "http://192.168.24.67:32769/go/files/Art/2/defaultStage/3/defaultJob/cruise-output/md5.checksum","type":
+        "file" } ] },{ "name": "foo","url": "http://192.168.24.67:32769/go/files/Art/2/defaultStage/3/defaultJob/foo","type":
+        "folder","files": [ { "name": "a.txt","url": "http://192.168.24.67:32769/go/files/Art/2/defaultStage/3/defaultJob/foo/a.txt","type":
+        "file" },{ "name": "b.txt","url": "http://192.168.24.67:32769/go/files/Art/2/defaultStage/3/defaultJob/foo/b.txt","type":
+        "file" } ] },{ "name": "output.txt","url": "http://192.168.24.67:32769/go/files/Art/2/defaultStage/3/defaultJob/output.txt","type":
+        "file" } ]'}
+    headers:
+      cache-control: ['max-age=1, no-cache']
+      connection: [close]
+      content-language: [en-US]
+      content-length: ['943']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 16 Sep 2015 12:58:13 GMT']
+      expires: ['Thu, 01 Jan 1970 00:00:00 GMT']
+      server: [Jetty(9.2.z-SNAPSHOT)]
+      set-cookie: ['JSESSIONID=1vuewuk513rz51ej1msw1bia2u;Path=/go;Expires=Wed, 30-Sep-2015
+          12:58:13 GMT']
+      vary: ['Accept-Encoding, User-Agent']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/goserver/artifact-cruise-config.xml
+++ b/tests/fixtures/goserver/artifact-cruise-config.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="75">
+  <server artifactsdir="artifacts" agentAutoRegisterKey="123456789abcdef" commandRepositoryLocation="default" serverId="0072a8d7-6563-4f53-a87e-dc7a9f17c82a" />
+  <pipelines group="defaultGroup">
+    <pipeline name="Art">
+      <materials>
+        <git url="http://192.168.24.41/gitt/.git/" />
+      </materials>
+      <stage name="defaultStage">
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="python">
+                <arg>stuff.py</arg>
+                <runif status="passed" />
+              </exec>
+              <exec command="bash">
+                <arg>-c</arg>
+                <arg>mkdir -p foo &amp;&amp; echo -n 5933126 &gt; foo/a.txt &amp;&amp; cp foo/a.txt foo/b.txt</arg>
+                <runif status="passed" />
+              </exec>
+              <exec command="bash">
+                <arg>-c</arg>
+                <arg>echo -n 3239273 &gt; output.txt</arg>
+                <runif status="passed" />
+              </exec>
+            </tasks>
+            <artifacts>
+              <artifact src="output.txt" />
+              <artifact src="foo" />
+            </artifacts>
+          </job>
+        </jobs>
+      </stage>
+    </pipeline>
+  </pipelines>
+  <agents>
+    <agent hostname="37d0a200592c" ipaddress="172.17.0.6" uuid="bc574ac3-26c4-42c7-8422-ebfea4228bfa" />
+  </agents>
+</cruise>
+


### PR DESCRIPTION
Here's the pull request for #3.

There's two issues with this that should be dealt before merging:
* The go server I used for my tests was hosted on a different address. The tests passes elsewhere due to the vcr lib, but no-one will be able to regenerate these files.
* The tests fail when the Go Server has authentication. Maybe this has something to do with the artifacts being /go/files instead of /go/api?

